### PR TITLE
Bugfix/table sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ The above example shows how to use the `#cell()` slot to customize the rendering
 | remotePagination    | Whether the pagination is handeled outside of the component or not. If `true` the prop `totalItems` must be set. |
 | filterDebounce    | Debounce interval in ms for the search (filter) input. Default is `250`. |
 | filterMaxWait    | Max wait time in ms for the search (filter) input. Default is `2000`.|
+| sortNullsFirst    | When `true` will sort `null\|undefined` first, when `false` will sort them last. Default value is `null` and causes a natural sort order, i.e `null\|undefined` will come first when sort direction is descending, `null\|undefined` will come last when sort direction is ascending. |
 
 ### Events
 | Event | Description |

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ We pass the table data as an array of objects via the `:items` attribute. The sa
  * `tdTopRowClassList`: classes for styling the column's `<td>` content (only applied to `:top-rows` records)
  * `tdBottomRowClassList`: classes for styling the column's `<td>` content (only applied to `:bottom-rows` records)
  * `formatter`: a function defining a formatting logic for the values of that field/column
+ * `type`: Either `numeric` or `alphanumeric`, explicitly influences sort behaviour
 
 Only those attributes present in the field array will be displayed in the resulting table.
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,8 +18,16 @@ function delay(ms) {
     return new Promise(resolve => setTimeout(resolve, ms))
 }
 // const items = await delay(2000).tehn(() => ref([...data]))
-const items = ref([...data])
-const topRows = ref([...data].slice(0, 5))
+const nullRecord = {
+    id: null,
+    first_name: null,
+    last_name: null,
+    email: null,
+    share: null,
+    ip_address: null
+}
+const items = ref([...data, nullRecord])
+const topRows = ref([...data].slice(0, 1))
 const fields = ref([
     {
         key: 'id',
@@ -242,7 +250,7 @@ const listSelection = ref([])
     <div class="un-p-3">
         <tab-card-component :tabs="tabs" :current-tab-index="0"></tab-card-component>
     </div>
-    <!-- <card-component class="un-mt-5">
+    <card-component class="un-mt-5">
         <loading-overlay :show="tableStatus.busy">
             <table-component
                 :items="items"
@@ -268,7 +276,7 @@ const listSelection = ref([])
                 </template>
             </table-component>
         </loading-overlay>
-    </card-component> -->
+    </card-component>
     <div class="un-p-2 un-text-gray-900 dark:un-text-gray-100">Some text above.</div>
     <div class="un-pl-8">
         <list-select

--- a/src/components/table/TableComponent.vue
+++ b/src/components/table/TableComponent.vue
@@ -331,7 +331,7 @@ export default {
             type: Number,
             default: 2000
         },
-        nullsFirst: {
+        sortNullsFirst: {
             type: Boolean,
             default: null
         }
@@ -457,7 +457,7 @@ export default {
 
             this.$emit('sort-change', { column: col, ascending: this.ascending })
             if (!this.remotePagination) {
-                sortTable(this.tableData, col, { ascending: this.ascending, nullsFirst: this.nullsFirst })
+                sortTable(this.tableData, col, { ascending: this.ascending, nullsFirst: this.sortNullsFirst })
                 if (this.paginate) {
                     this.changePage(1)
                 }

--- a/src/components/table/TableComponent.vue
+++ b/src/components/table/TableComponent.vue
@@ -185,18 +185,7 @@ import { joinLines } from '@/utils/string-join-lines.js'
 import 'virtual:uno.css'
 import { nanoid } from 'nanoid'
 import { useDebounceFn } from '@vueuse/core'
-
-function numSort(a, b, ascending) {
-    return ascending ? a - b : b - a
-}
-
-function alnumSort(a, b, ascending) {
-    const direction = ascending ? 1 : -1
-    const comparison = a.localeCompare(b, undefined, {
-        sensitivity: 'base'
-    })
-    return comparison * direction
-}
+import { sortTable } from './table-sort'
 
 function textMatch(needle, haystack) {
     const lowerCasedNeedle = needle.toLowerCase()
@@ -341,6 +330,10 @@ export default {
         filterMaxWait: {
             type: Number,
             default: 2000
+        },
+        nullsFirst: {
+            type: Boolean,
+            default: null
         }
     },
     data() {
@@ -464,17 +457,7 @@ export default {
 
             this.$emit('sort-change', { column: col, ascending: this.ascending })
             if (!this.remotePagination) {
-                this.tableData.sort((a, b) => {
-                    const aVal = a[col.key]
-                    const bVal = b[col.key]
-                    if (Number.isNaN(+aVal) && Number.isNaN(+bVal)) {
-                        return alnumSort(aVal, bVal, this.ascending)
-                    } else if ([aVal, bVal].every(n => !Number.isNaN(+n))) {
-                        return numSort(aVal, bVal, this.ascending)
-                    } else {
-                        return 0
-                    }
-                })
+                sortTable(this.tableData, col, { ascending: this.ascending, nullsFirst: this.nullsFirst })
                 if (this.paginate) {
                     this.changePage(1)
                 }

--- a/src/components/table/__tests__/TableSort.spec.js
+++ b/src/components/table/__tests__/TableSort.spec.js
@@ -1,0 +1,335 @@
+import { describe, it, expect } from 'vitest'
+import { sortTable, guessSortType } from '../table-sort'
+
+describe('TableSort', () => {
+    describe('should guess sort type', () => {
+        it('numeric', () => {
+            const tableData = [{ a: null }, { a: undefined }, { a: 1 }, { a: 2 }, { a: 3 }]
+            const col = { key: 'a' }
+            const type = guessSortType(tableData, col)
+            expect(type).toBe('numeric')
+        })
+        it('alphanumeric', () => {
+            const tableData = [{ a: null }, { a: undefined }, { a: 'a' }, { a: 'b' }, { a: 'c' }]
+            const col = { key: 'a' }
+            const type = guessSortType(tableData, col)
+            expect(type).toBe('alphanumeric')
+        })
+        it('alphanumeric with mixed data types', () => {
+            const tableData = [{ a: null }, { a: undefined }, { a: 'a' }, { a: 'b' }, { a: 3 }]
+            const col = { key: 'a' }
+            const type = guessSortType(tableData, col)
+            expect(type).toBe('alphanumeric')
+        })
+    })
+    describe('should sort numbers', () => {
+        it('ascending & nulls last per default', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col)
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }, { a: null }])
+        })
+        it('descending & nulls first when nullsFirst is not provided', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false })
+            expect(tableData).toEqual([{ a: null }, { a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }])
+        })
+        it('descending', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending with nullsFirst', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }])
+        })
+        it('descending with nullsFirst', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending with nullsLast', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }, { a: null }])
+        })
+        it('descending with nullsLast', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }, { a: null }])
+        })
+        it('ascending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: undefined }, { a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }])
+        })
+        it('descending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: undefined }, { a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 10 }, { a: 12 }, { a: undefined }])
+        })
+        it('descending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 10 }, { a: 12 }, { a: 1 }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'numeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 12 }, { a: 10 }, { a: 5 }, { a: 1 }, { a: undefined }])
+        })
+    })
+
+    describe('should sort strings', () => {
+        it('ascending & nulls last per default', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col)
+            expect(tableData).toEqual([{ a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }, { a: null }])
+        })
+        it('descending & nulls first when nullsFirst is not provided', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false })
+            expect(tableData).toEqual([{ a: null }, { a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }])
+        })
+        it('ascending', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }])
+        })
+        it('descending', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }])
+        })
+        it('ascending with nullsFirst', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }])
+        })
+        it('descending with nullsFirst', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }])
+        })
+        it('ascending with nullsLast', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }, { a: null }])
+        })
+        it('descending with nullsLast', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }, { a: null }])
+        })
+        it('ascending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([
+                { a: undefined },
+                { a: 'a' },
+                { a: 'b' },
+                { a: 'c' },
+                { a: 'd' }
+            ])
+        })
+        it('descending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([
+                { a: undefined },
+                { a: 'd' },
+                { a: 'c' },
+                { a: 'b' },
+                { a: 'a' }
+            ])
+        })
+        it('ascending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([
+                { a: 'a' },
+                { a: 'b' },
+                { a: 'c' },
+                { a: 'd' },
+                { a: undefined }
+            ])
+        })
+        it('descending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([
+                { a: 'd' },
+                { a: 'c' },
+                { a: 'b' },
+                { a: 'a' },
+                { a: undefined }
+            ])
+        })
+        it('ascending with nullsFirst and empty strings', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: '' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: '' }, { a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }])
+        })
+        it('descending with nullsFirst and empty strings', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: '' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: '' }, { a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }])
+        })
+        it('ascending with nullsLast and empty strings', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: '' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 'a' }, { a: 'b' }, { a: 'c' }, { a: 'd' }, { a: '' }])
+        })
+        it('descending with nullsLast and empty strings', () => {
+            const tableData = [{ a: 'c' }, { a: 'a' }, { a: 'b' }, { a: 'd' }, { a: '' }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 'd' }, { a: 'c' }, { a: 'b' }, { a: 'a' }, { a: '' }])
+        })
+    })
+
+    describe('should sort mixed data', () => {
+        it('ascending & nulls last per default', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col)
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 'b' }, { a: 'c' }, { a: null }])
+        })
+        it('descending & nulls first when nullsFirst is not provided', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false })
+            expect(tableData).toEqual([{ a: null }, { a: 'c' }, { a: 'b' }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 'b' }, { a: 'c' }])
+        })
+        it('descending', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: 'c' }, { a: 'b' }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending with nullsFirst', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 1 }, { a: 5 }, { a: 'b' }, { a: 'c' }])
+        })
+        it('descending with nullsFirst', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([{ a: null }, { a: 'c' }, { a: 'b' }, { a: 5 }, { a: 1 }])
+        })
+        it('ascending with nullsLast', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 'b' }, { a: 'c' }, { a: null }])
+        })
+        it('descending with nullsLast', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([{ a: 'c' }, { a: 'b' }, { a: 5 }, { a: 1 }, { a: null }])
+        })
+        it('ascending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: true })
+            expect(tableData).toEqual([
+                { a: undefined },
+                { a: 1 },
+                { a: 5 },
+                { a: 'b' },
+                { a: 'c' }
+            ])
+        })
+        it('descending with nullsFirst and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: true })
+            expect(tableData).toEqual([
+                { a: undefined },
+                { a: 'c' },
+                { a: 'b' },
+                { a: 5 },
+                { a: 1 }
+            ])
+        })
+        it('ascending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: true, nullsFirst: false })
+            expect(tableData).toEqual([
+                { a: 1 },
+                { a: 5 },
+                { a: 'b' },
+                { a: 'c' },
+                { a: undefined }
+            ])
+        })
+        it('descending with nullsLast and invalid values', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: undefined }]
+            const col = { key: 'a', type: 'alphanumeric' }
+            sortTable(tableData, col, { ascending: false, nullsFirst: false })
+            expect(tableData).toEqual([
+                { a: 'c' },
+                { a: 'b' },
+                { a: 5 },
+                { a: 1 },
+                { a: undefined }
+            ])
+        })
+    })
+    describe('should sort data with unspecified type alphanumeric', () => {
+        it('ascending & nulls last per default', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a' }
+            sortTable(tableData, col)
+            expect(tableData).toEqual([{ a: 1 }, { a: 5 }, { a: 'b' }, { a: 'c' }, { a: null }])
+        })
+        it('descending & nulls first when nullsFirst is not provided', () => {
+            const tableData = [{ a: 'c' }, { a: 1 }, { a: 'b' }, { a: 5 }, { a: null }]
+            const col = { key: 'a' }
+            sortTable(tableData, col, { ascending: false })
+            expect(tableData).toEqual([{ a: null }, { a: 'c' }, { a: 'b' }, { a: 5 }, { a: 1 }])
+        })
+    })
+})

--- a/src/components/table/table-sort.js
+++ b/src/components/table/table-sort.js
@@ -1,0 +1,58 @@
+function numSort(a, b, ascending, nullsFirst) {
+    if (!a) {
+        return nullsFirst ? -1 : 1
+    }
+    if (!b) {
+        return nullsFirst ? 1 : -1
+    }
+    return ascending ? a - b : b - a
+}
+
+function alnumSort(a, b, ascending, nullsFirst) {
+    const direction = ascending ? 1 : -1
+    if (!validForAlnumSort(a)) {
+        return nullsFirst ? -1 : 1
+    }
+    if (!validForAlnumSort(b)) {
+        return nullsFirst ? 1 : -1
+    }
+    const aVal = a.toString()
+    const bVal = b.toString()
+    const comparison = aVal.localeCompare(bVal, undefined, {
+        sensitivity: 'base'
+    })
+    return comparison * direction
+}
+
+const sortTypes = Object.freeze({ NUMERIC: 'numeric', ALPHANUMERIC: 'alphanumeric' })
+
+const validForAlnumSort = val => {
+    return val && typeof ('' + val) === 'string'
+}
+
+const validForNumSort = val => val && typeof val === 'number' && Number.isNaN(val) === false
+
+export function guessSortType(tableData, col) {
+    const hasNonNumeric = tableData
+        .filter(row => row[col.key])
+        .some(row => !validForNumSort(row[col.key]))
+    return hasNonNumeric ? sortTypes.ALPHANUMERIC : sortTypes.NUMERIC
+}
+
+const getSortFn = (tableData, col) => {
+    const sortFunctions = {
+        numeric: numSort,
+        alphanumeric: alnumSort
+    }
+    const sortFunction = sortFunctions[col.type]
+    return sortFunction ? sortFunction : sortFunctions[guessSortType(tableData, col)]
+}
+
+export function sortTable(tableData, col, { ascending = true, nullsFirst = null } = {}) {
+    const sortFn = getSortFn(tableData, col)
+    return tableData.sort((a, b) => {
+        const aVal = a[col.key]
+        const bVal = b[col.key]
+        return sortFn(aVal, bVal, ascending, nullsFirst === null ? !ascending : nullsFirst)
+    })
+}


### PR DESCRIPTION
* Fixes inconsistent sorting behaviour when dealing with mixed data types.
* Introduces new schema property `type` ('numeric'/'alphanumeric') to explicitly set sorting behaviour
* For compatibility a fallback does a best-guess based on data
* Adds explicit handling of `null|undefined` values (first, last, or natural order)
